### PR TITLE
Add macro flag to identify triggering entity

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -111,7 +111,9 @@ class TriggerHappy {
                     else
                         await effect.view();
                 } else if (effect.entity === "Macro") {
+                    effect.setFlag("trigger-happy", "trigger", {entity: trigger.entity, id: trigger.id}); 
                     await effect.execute();
+                    effect.unsetFlag("trigger-happy", "trigger")
                 } else if (effect.entity === "RollTable") {
                     await effect.draw();
                 } else if (effect.entity === "ChatMessage") {


### PR DESCRIPTION
At present it is difficult to identify within a macro which entity triggered it. This makes reusing macros for recurring triggers difficult because they require either duplicate copies for each trigger or detection workarounds. This change simplifies the process by creating a time-limited flag on the `Macro` itself identifying the entity type and its id, which can be accessed from within the macro.