### PR TITLE
Ensure 'tgw' and 'tgh' is an integer instead of a float

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -398,8 +398,8 @@ class TriggerHappy {
         const ty = target.y;
         const tw = target.w || target.data.width;
         const th = target.h || target.data.height;
-        const tgw = target.data.width / gridSize; // target token width in grid units
-        const tgh = target.data.height / gridSize; // target token height in grid units
+        const tgw = Math.ceil(target.data.width / gridSize); // target token width in grid units
+        const tgh = Math.ceil(target.data.height / gridSize); // target token height in grid units
         // test motion vs token diagonals
         if (tgw > 1 && tgh > 1 && tgw * tgh > 4) {
             // big token so do boundary lines


### PR DESCRIPTION
In some cases when the screen resolution is off as was on my monitor (619px instead of 700px), the value of `tgw` and `tgh` ends up as a float causing an issue on line 422 when trying to fill an array. The error message was 

![FoundryVTT JS Issue 1](https://user-images.githubusercontent.com/9334376/121661465-cca35380-cad6-11eb-9cec-08bcbfe0e41b.PNG)

This fix ensures both values are always an integer therefore preventing the above error message.

Monitor resolution
![FoundryVTT Resolution Issue](https://user-images.githubusercontent.com/9334376/121661304-a5e51d00-cad6-11eb-9068-219a1b99c84b.PNG)
