### PR TITLE
Update entity matching to allow up to 2 levels of nested brackets []

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -510,7 +510,10 @@ export class TriggerHappy {
     const entityLinks = Object.keys(CONFIG).concat(this.arrayTriggers);
     entityLinks.push(...this.registeredEffects);
 
-    const entityMatchRgx = `@(${entityLinks.join('|')})\\[([^\\]]+)\\](?:{([^}]+)})?`;
+    //const entityMatchRgx = `@(${entityLinks.join('|')})\\[([^\\]]+)\\](?:{([^}]+)})?`;
+    const entityMatchRgx = `@(${entityLinks.join('|')})\\[((?:[^\[\\]]+|\\[(?:[^\\[\\]]+|\\[[^\\[\\]]*\\])*\\])*)\\](?:{([^}]+)})?`;
+    
+    
     const rgx = new RegExp(entityMatchRgx, 'ig');
 
     const entityMatchRgxTagger = `@(Tag)\\[([^\\]]+)\\]`;


### PR DESCRIPTION
I added a new Trigger Happy entity in the GURPS Game Aid for Foundry code (https://foundryvtt.com/packages/gurps), using the game.triggers.registerEffect() function:   `@OTF[]`

OTF stands for "On the Fly", a syntax that allows the user to create buttons (and perform actions) "on the fly".   You can see the complete syntax (and examples) here:   https://docs.google.com/document/d/1NMBPt9KhA9aGG1_kZxyk8ncuOKhz9Z6o7vPS8JcjdWc/edit#heading=h.4i42gorf4hic

The player can edit their character sheet and enter in text like: `[PER]` (which creates a button that will roll the Perception attribute of the character, or they can create something more complex like:

`["Acrobatic Dodge"/if [Sk:Acrobatics] [Dodge+2] /else [Dodge-2]]`

Which will create a button with the label "Acrobatic Dodge".   When the button is pressed, it will execute the Skill check for the Acrobatics skill, and if successful, it will roll against the characters Dodge with a +2 modifier, otherwise it will roll against Dodge at a -2.

**As you can see... OTF formulas rely on square brackets, and the original regex would match:**
`["Acrobatic Dodge"/if [Sk:Acrobatics] [Dodge+2] [Dodge-2]]` to `["Acrobatic Dodge"/if [Sk:Acrobatics]`
**which was not complete.**

This Pull Request updates the regex to allow at least 2 levels of matched square brackets.

I found this example of how to match balanced brackets here:  https://stackoverflow.com/questions/546433/regular-expression-to-match-balanced-parentheses