### PR TITLE
Fix Trigger Happy folder check for v10

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -464,7 +464,7 @@ export class TriggerHappy {
 
     return folders.reduce((contents, folder) => {
       // Cannot use folder.content and folder.children because they are set on populate and only show what the user can see
-      let content = game.journal.contents.filter((j) => j.folder === folder.id) || []; // This is the array of journalEntry under the current folder
+      let content = game.journal.contents.filter((j) => j.folder?.id === folder.id) || []; // This is the array of journalEntry under the current folder
       if (enableJournalForScene) {
         const contentTmp = [];
         content.forEach((journalEntry) => {
@@ -482,7 +482,7 @@ export class TriggerHappy {
         content = contentTmp;
       }
       if (content && content.length > 0) contents.push(...content);
-      const children = game.folders.contents.filter((f) => f.type === 'JournalEntry' && f.parent === folder.id);
+      const children = game.folders.contents.filter((f) => f.type === 'JournalEntry' && f.folder?.id === folder.id);
       return this._getFoldersContentsRecursive(children, contents);
     }, contents);
   }


### PR DESCRIPTION
In v10, it looks like a journal's "folder" field is now a Folder object instead of an id, and in a folder's object, the parent folder is stored in the "folder" field, not "parent".
This fixes Trigger Happy when using a folder for the journals.